### PR TITLE
Fix Northings & Dynamic Framework Wrapping (SF dependency)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,13 +11,15 @@ let package = Package(
             targets: ["MGRS"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ngageoint/grid-ios", from: "2.0.0")
+        .package(url: "https://github.com/ngageoint/grid-ios", from: "2.0.0"),
+        .package(url: "https://github.com/ngageoint/simple-features-ios", from: "5.0.0")
     ],
     targets: [
         .target(
             name: "MGRS",
             dependencies: [
-                .product(name: "Grid", package: "grid-ios")
+                .product(name: "Grid", package: "grid-ios"),
+                .product(name: "SimpleFeatures", package: "simple-features-ios")
             ],
             path: "mgrs-ios",
             resources: [

--- a/mgrs-ios/MGRS.swift
+++ b/mgrs-ios/MGRS.swift
@@ -321,7 +321,11 @@ public class MGRS: Hashable {
         // (100km square boundaries are aligned with 100km UTM northing
         // intervals)
 
-        let latBandNorthing = UTM.from(GridPoint.degrees(0, latBand)).northing
+        // *** THIS BLOCK IS THE UPDATE ***
+        // UTM northing at a band's southern edge depends on longitude; use this
+        // zone's central meridian so the 2,000km block selection is correct.
+        let centralMeridian = Double(zone * 6 - 183)
+        let latBandNorthing = UTM.from(GridPoint.degrees(centralMeridian, latBand)).northing
         let nBand = floor(latBandNorthing / 100000) * 100000
 
         // 100km grid square row letters repeat every 2,000km north; add enough


### PR DESCRIPTION
- Bug fix: 100km grid square row letter calculation used hardcoded longitude 0° to compute band-edge UTM northing, which is incorrect — UTM northing at a given latitude varies by zone. Now uses the zone's central meridian (zone * 6 - 183). See https://github.com/ngageoint/mgrs-ios/issues/8
- Dependency fix: Added explicit simple-features-ios dependency. MGRS uses SFGeometryUtils directly but only declared Grid as a dependency — works with static linking but breaks under Xcode 16+'s default dynamic framework wrapping for tests.